### PR TITLE
Incremental build

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ We always use base paths for applications so it is easier for infra to handle ou
 
 
 ### Build
-Building the web application will automatically run `npm install && npm run build`.
+Building the web application will automatically run `npm install && npm run build`. An incremental build is used so that these commands are only run if relevant files are modified, e.g. `main.scss` is modified.  
+The commands can be forced to run by a Rebuild in Visual Studio or running `dotnet --no-incremental` if using the CLI.
 
 The `npm install` command installs all NPM dependencies listed within the `package.json`.
 

--- a/src/nhsuk.base-application/nhsuk.base-application.csproj
+++ b/src/nhsuk.base-application/nhsuk.base-application.csproj
@@ -63,16 +63,9 @@
     Regeneration of output files can be forced via a rebuild (or clean then build).
     If using the dotnet command line, the "no-incremental" flag must be set to do a "rebuild".
   -->
-  <Target Name="Build frontend" BeforeTargets="Build other" Inputs="@(FrontendInputs)" Outputs="$(FrontendBuildStampFile)">
+  <Target Name="Build frontend" BeforeTargets="BeforeBuild" Inputs="@(FrontendInputs)" Outputs="$(FrontendBuildStampFile)">
     <Exec Command="npm run build" />
     <Touch Files="$(FrontendBuildStampFile)" AlwaysCreate="true" />
-  </Target>
-
-  <!-- Moved out of "Build frontend", as assumed this is needed for every build. -->
-  <Target Name="Build other" BeforeTargets="BeforeBuild">
-    <ItemGroup>
-      <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(BaseIntermediateOutputPath)**;$(BaseOutputPath)**;@(Compile)" />
-    </ItemGroup>
   </Target>
 
   <Target Name="ResetNpmInstallStampFile" AfterTargets="CoreClean">

--- a/src/nhsuk.base-application/nhsuk.base-application.csproj
+++ b/src/nhsuk.base-application/nhsuk.base-application.csproj
@@ -5,6 +5,20 @@
     <RootNamespace>nhsuk.base_application</RootNamespace>
   </PropertyGroup>
 
+  <!--
+    Include frontend assets in the "fast up-to-date check". Otherwise project will be seen by msbuild as up-to-date if
+    only one of these files has been changed and will skip running the targets, including the build frontend target.
+    See https://jacobdixon.uk/2020/10/compile-scss-at-build-time-visual-studio
+  -->
+  <ItemGroup>
+    <UpToDateCheckInput Include="wwwroot/src/scss/**/*.scss" Set="css" />
+    <UpToDateCheckBuilt Include="wwwroot/dist/*.css" Set="css" />
+    <UpToDateCheckInput Include="wwwroot/src/js/**/*.js" Set="js" />
+    <UpToDateCheckBuilt Include="wwwroot/dist/*.js" Set="js" />
+    <UpToDateCheckInput Include="wwwroot/src/images/**/*" Set="images" />
+    <UpToDateCheckBuilt Include="wwwroot/dist/images/**/*" Set="images" />
+  </ItemGroup>
+
   <!-- Uncomment to use header and footer Nuget package <ItemGroup>
     <PackageReference Include="NhsUk.header-footer-api-client" Version="2.1.0" />
   </ItemGroup> -->
@@ -18,4 +32,5 @@
       <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(BaseIntermediateOutputPath)**;$(BaseOutputPath)**;@(Compile)" />
     </ItemGroup>
   </Target>
+
 </Project>

--- a/src/nhsuk.base-application/nhsuk.base-application.csproj
+++ b/src/nhsuk.base-application/nhsuk.base-application.csproj
@@ -12,11 +12,13 @@
   </PropertyGroup>
 
   <!--
-    Frontend source files. Frontend build will only run if one of the files matched by the Include has been modified
-    since the last frontend build. Clean/Rebuild to force a frontend build.
+    Frontend build will only run if one of the files matched by the Includes has been modified since the last
+    frontend build. Clean/Rebuild to force a frontend build.
   -->
   <ItemGroup>
     <FrontendInputs Include="wwwroot/src/**/*" />
+    <!-- Assumed that a change to the npm packages could change the compiled files. -->
+    <FrontendInputs Include="package.json" />
   </ItemGroup>
 
   <!--
@@ -57,7 +59,8 @@
   </Target>
 
   <!--
-    Only build frontend if at least one of the frontend source files was modified since the last frontend build.
+    Only build frontend if at least one of the frontend source files was modified since the last frontend build,
+    or if packages.json has been updated since the last frontend build.
     Will always be run if $(FrontendBuildStampFile) does not exist (e.g. the very first build).
     Deleted source or output files won't trigger a build. Manually modified output files will not trigger a build.
     Regeneration of output files can be forced via a rebuild (or clean then build).

--- a/src/nhsuk.base-application/nhsuk.base-application.csproj
+++ b/src/nhsuk.base-application/nhsuk.base-application.csproj
@@ -5,10 +5,19 @@
     <RootNamespace>nhsuk.base_application</RootNamespace>
   </PropertyGroup>
 
-  <!-- Paths of time stamps file for use in incremental build. -->
+  <!-- Paths of time stamp files for use in incremental builds. -->
   <PropertyGroup>
     <NpmInstallStampFile>node_modules/.install-stamp</NpmInstallStampFile>
+    <FrontendBuildStampFile>node_modules/.build-stamp</FrontendBuildStampFile>
   </PropertyGroup>
+
+  <!--
+    Frontend source files. Frontend build will only run if one of the files matched by the Include has been modified
+    since the last frontend build. Clean/Rebuild to force a frontend build.
+  -->
+  <ItemGroup>
+    <FrontendInputs Include="wwwroot/src/**/*" />
+  </ItemGroup>
 
   <!--
     Include frontend assets in the "fast up-to-date check". Otherwise project will be seen by msbuild as up-to-date if
@@ -47,17 +56,33 @@
     <Touch Files="$(NpmInstallStampFile)" AlwaysCreate="true" />
   </Target>
 
-  <Target Name="Build frontend" BeforeTargets="BeforeBuild">
+  <!--
+    Only build frontend if at least one of the frontend source files was modified since the last frontend build.
+    Will always be run if $(FrontendBuildStampFile) does not exist (e.g. the very first build).
+    Deleted source or output files won't trigger a build. Manually modified output files will not trigger a build.
+    Regeneration of output files can be forced via a rebuild (or clean then build).
+    If using the dotnet command line, the "no-incremental" flag must be set to do a "rebuild".
+  -->
+  <Target Name="Build frontend"
+          BeforeTargets="Build other"
+          Inputs="@(FrontendInputs)"
+          Outputs="$(FrontendBuildStampFile)">
     <Exec Command="npm run build" />
+    <Touch Files="$(FrontendBuildStampFile)" AlwaysCreate="true" />
+  </Target>
+
+  <!-- Moved out of "Build frontend", as assumed this is needed for every build. -->
+  <Target Name="Build other" BeforeTargets="BeforeBuild">
     <ItemGroup>
       <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(BaseIntermediateOutputPath)**;$(BaseOutputPath)**;@(Compile)" />
     </ItemGroup>
   </Target>
 
-  <Target Name="ResetNpmInstallStampFile"
-          AfterTargets="CoreClean">
+  <Target Name="ResetNpmInstallStampFile" AfterTargets="CoreClean">
     <!-- Delete time stamp to force npm install to re-run on next build. -->
     <Delete Files="$(NpmInstallStampFile)" />
+    <!-- Delete time stamp to force building "frontend" on next build. -->
+    <Delete Files="$(FrontendBuildStampFile)" />
   </Target>
 
 </Project>

--- a/src/nhsuk.base-application/nhsuk.base-application.csproj
+++ b/src/nhsuk.base-application/nhsuk.base-application.csproj
@@ -1,8 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>nhsuk.base_application</RootNamespace>
+  </PropertyGroup>
+
+  <!-- Paths of time stamps file for use in incremental build. -->
+  <PropertyGroup>
+    <NpmInstallStampFile>node_modules/.install-stamp</NpmInstallStampFile>
   </PropertyGroup>
 
   <!--
@@ -25,12 +30,34 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
-  <Target Name="Build frontend" BeforeTargets="BeforeBuild">
+
+  <!--
+    Only run "npm install" if packages.json has been updated since the last time it was run.
+    Will always be run if $(NpmInstallStampFile) does not exist (e.g. the very first build).
+    Deleted output files won't trigger a build. Manually modified output files will not trigger a build.
+    Regeneration of output files can be forced via a rebuild (or clean then build).
+    If using the dotnet command line, the "no-incremental" flag must be set to do a "rebuild".
+    (Based on: https://stackoverflow.com/a/48020233)
+  -->
+  <Target Name="NpmInstall"
+          BeforeTargets="Build frontend"
+          Inputs="package.json"
+          Outputs="$(NpmInstallStampFile)">
     <Exec Command="npm install" />
+    <Touch Files="$(NpmInstallStampFile)" AlwaysCreate="true" />
+  </Target>
+
+  <Target Name="Build frontend" BeforeTargets="BeforeBuild">
     <Exec Command="npm run build" />
     <ItemGroup>
       <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(BaseIntermediateOutputPath)**;$(BaseOutputPath)**;@(Compile)" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="ResetNpmInstallStampFile"
+          AfterTargets="CoreClean">
+    <!-- Delete time stamp to force npm install to re-run on next build. -->
+    <Delete Files="$(NpmInstallStampFile)" />
   </Target>
 
 </Project>

--- a/src/nhsuk.base-application/nhsuk.base-application.csproj
+++ b/src/nhsuk.base-application/nhsuk.base-application.csproj
@@ -50,10 +50,7 @@
     If using the dotnet command line, the "no-incremental" flag must be set to do a "rebuild".
     (Based on: https://stackoverflow.com/a/48020233)
   -->
-  <Target Name="NpmInstall"
-          BeforeTargets="Build frontend"
-          Inputs="package.json"
-          Outputs="$(NpmInstallStampFile)">
+  <Target Name="NpmInstall" BeforeTargets="Build frontend" Inputs="package.json" Outputs="$(NpmInstallStampFile)">
     <Exec Command="npm install" />
     <Touch Files="$(NpmInstallStampFile)" AlwaysCreate="true" />
   </Target>
@@ -66,10 +63,7 @@
     Regeneration of output files can be forced via a rebuild (or clean then build).
     If using the dotnet command line, the "no-incremental" flag must be set to do a "rebuild".
   -->
-  <Target Name="Build frontend"
-          BeforeTargets="Build other"
-          Inputs="@(FrontendInputs)"
-          Outputs="$(FrontendBuildStampFile)">
+  <Target Name="Build frontend" BeforeTargets="Build other" Inputs="@(FrontendInputs)" Outputs="$(FrontendBuildStampFile)">
     <Exec Command="npm run build" />
     <Touch Files="$(FrontendBuildStampFile)" AlwaysCreate="true" />
   </Target>


### PR DESCRIPTION
Incremental build targets for "installl npm" and "build frontend".
Install npm only runs if there has been a change to the packages, i.e. if package.json was modified since the last build.
Build frontend only runs if any of the frontend files have been modified since the last build or if package.json has changed.
A rebuild will force running npm install and build frontend regardless of last modified dates.
Significantly speeds up the build in development when only "non-frontend" changes have been made (e.g. C# or .cshtml views).